### PR TITLE
Add SRE-style /health and /status easter egg endpoints

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -13,6 +13,11 @@ const terminalCommand = 'kubectl get events';
       <span class="footer__cursor" id="footer-terminal-cursor" aria-hidden="true"></span>
     </p>
     <p class="footer__tagline">{cv.footer.tagline}</p>
+    <p class="footer__probes" aria-label="Observability endpoints">
+      <span class="footer__probes-label">probes</span>
+      <a href="/health">/health</a>
+      <a href="/status">/status</a>
+    </p>
   </div>
 </footer>
 
@@ -85,6 +90,34 @@ const terminalCommand = 'kubectl get events';
   .footer__tagline {
     font-size: 0.85rem;
     color: var(--color-text-muted);
+  }
+
+  .footer__probes {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--color-text-muted);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem 0.85rem;
+  }
+
+  .footer__probes-label {
+    color: var(--color-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.62rem;
+  }
+
+  .footer__probes a {
+    color: var(--color-mono);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .footer__probes a:hover {
+    color: var(--color-accent);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/components/ops/OpsHeader.astro
+++ b/src/components/ops/OpsHeader.astro
@@ -1,0 +1,36 @@
+---
+interface Props {
+  endpoint: string;
+  jsonPath: string;
+  probeType: 'liveness' | 'readiness';
+}
+
+const { endpoint, jsonPath, probeType } = Astro.props;
+const siteUrl = 'https://dbcelm.github.io';
+const curlTarget = `${siteUrl}${jsonPath}`;
+---
+
+<header class="ops-top">
+  <p class="ops-top__crumb">
+    <span class="ops-dim">probe</span> {probeType}
+    <span class="ops-sep">·</span>
+    <span class="ops-dim">path</span> {endpoint}
+  </p>
+  <div class="ops-curl">
+    <span class="ops-label">For machines (and curious SREs)</span>
+    <code>curl -s {curlTarget} | jq</code>
+  </div>
+</header>
+
+<style>
+  .ops-top {
+    margin-bottom: var(--space-md);
+  }
+
+  .ops-top__crumb {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--color-mono);
+    margin-bottom: var(--space-sm);
+  }
+</style>

--- a/src/data/ops-endpoints.ts
+++ b/src/data/ops-endpoints.ts
@@ -1,0 +1,273 @@
+export type CheckStatus = 'UP' | 'DOWN' | 'DEGRADED' | 'FLAPPING' | 'UNKNOWN' | 'DENIED';
+
+export interface OpsCheck {
+  status: CheckStatus;
+  detail?: string;
+  [key: string]: string | number | boolean | undefined;
+}
+
+const siteVersion = import.meta.env.PUBLIC_SITE_VERSION?.trim() || 'dev';
+const buildTime = new Date().toISOString();
+
+export function getSiteVersion() {
+  return siteVersion;
+}
+
+export function getBuildTime() {
+  return buildTime;
+}
+
+export function getHealthPayload() {
+  return {
+    status: 'UP' as const,
+    probe: 'HTTP GET /health',
+    service: 'ayush-tiwari-cv',
+    version: siteVersion,
+    built_at: buildTime,
+    message: "Liveness confirmed. Of course I have /health. I'm not a static brochure.",
+    sre_mandate: 'compliant',
+    checks: {
+      heartbeat: {
+        status: 'UP',
+        detail: 'Still caffeinated. No restart required.',
+      },
+      career: {
+        status: 'UP',
+        tenure: '10+ years',
+        detail: 'Platform engineering is a feature, not a bug.',
+      },
+      imposter_syndrome: {
+        status: 'FLAPPING',
+        detail: 'Recovered after a clean terraform plan.',
+        remediation: 'kubectl explain confidence',
+      },
+      yaml: {
+        status: 'UP',
+        indentation: '2 spaces',
+        tabs: 'rejected at admission controller',
+      },
+      pager: {
+        status: 'UP',
+        silenced: false,
+        detail: 'Pager is armed. Mom has the escalation path.',
+      },
+      friday_deploys: {
+        status: 'DENIED',
+        policy: 'change-freeze-friday',
+        detail: "This endpoint was deployed on a weekday. You're welcome.",
+      },
+      dns: {
+        status: 'UP',
+        detail: 'Not the root cause today. Check again tomorrow.',
+      },
+      coffee: {
+        status: 'DEGRADED',
+        level: 'refill recommended',
+        detail: 'Non-blocking for HTTP 200 responses.',
+      },
+    },
+    hints: {
+      json: '/health.json',
+      readiness: '/status',
+      home: '/',
+    },
+  };
+}
+
+export function getStatusPayload() {
+  return {
+    status: 'READY' as const,
+    probe: 'HTTP GET /status',
+    service: 'ayush-tiwari-cv',
+    version: siteVersion,
+    built_at: buildTime,
+    environment: 'production',
+    region: 'github-pages-us-east-1',
+    message: 'All dependencies nominal. Resume is downloadable. Dad jokes within SLO.',
+    ownership: {
+      team: 'platform-engineering-of-one',
+      oncall: 'ayush@dbcelm.github.io',
+      runbook: 'kubectl get events, then coffee',
+    },
+    dependencies: [
+      {
+        name: 'github-pages',
+        status: 'HEALTHY',
+        version: 'latest',
+        note: 'Static assets. Boring in the best way.',
+      },
+      {
+        name: 'github-actions',
+        status: 'HEALTHY',
+        note: 'Tags on push. Deploys after security. Civilization.',
+      },
+      {
+        name: 'astro',
+        status: 'HEALTHY',
+        note: 'Builds this page so you can read this joke.',
+      },
+      {
+        name: 'kubernetes.experience',
+        status: 'HEALTHY',
+        replicas: '700+ clusters operated',
+        note: 'Emotionally available for multi-tenant questions.',
+      },
+      {
+        name: 'terraform',
+        status: 'HEALTHY',
+        note: 'State is remote. Feelings are local.',
+      },
+      {
+        name: 'coffee-supply-chain',
+        status: 'DEGRADED',
+        reason: 'afternoon slump',
+        mitigation: 'espresso rollout in progress',
+      },
+      {
+        name: 'friday-deploy-policy',
+        status: 'DENIED',
+        http_code: 451,
+        note: "Come back Monday. Or don't. I'm not your manager.",
+      },
+    ],
+    slos: [
+      {
+        name: 'site_availability',
+        target: '99.9%',
+        actual: '100% (it is static HTML)',
+        error_budget: 'infinite until someone adds a database',
+      },
+      {
+        name: 'recruiter_response_time',
+        target: '48h',
+        actual: 'calendar-dependent',
+        error_budget: 'rechargeable via coffee',
+      },
+      {
+        name: 'dad_jokes_per_deploy',
+        target: '>= 1',
+        actual: 'exceeded',
+        error_budget: 'none remaining. Sorry.',
+      },
+      {
+        name: 'mean_time_to_coffee',
+        target: 'PT5M',
+        actual: 'PT4M30S',
+        error_budget: 'healthy',
+      },
+    ],
+    capacity: {
+      years_experience: '10+',
+      nodes_managed: '1500+',
+      clusters_operated: '700+',
+      cloud_savings_usd: '250K+',
+      patience: 'HIGH',
+      tolerance_for_manual_deploys: 'LOW',
+    },
+    incidents: [
+      {
+        id: 'INC-404',
+        title: 'Career path not found',
+        status: 'resolved',
+        resolution: 'Redeployed as DevOps. 200 OK ever since.',
+      },
+      {
+        id: 'INC-503',
+        title: 'Meeting overload',
+        status: 'mitigated',
+        resolution: 'Scaled calendar horizontally. Added async updates.',
+      },
+      {
+        id: 'INC-418',
+        title: 'I am a teapot',
+        status: 'closed',
+        resolution: 'RFC 2324 acknowledged. Brewed coffee instead.',
+      },
+    ],
+    pods: [
+      {
+        name: 'cv-frontend-0',
+        ready: '1/1',
+        status: 'Running',
+        restarts: 0,
+        age: siteVersion,
+      },
+      {
+        name: 'terraform-plan-7f3a',
+        ready: '0/1',
+        status: 'Completed',
+        restarts: 12,
+        age: '2y',
+        note: 'Eventually converged.',
+      },
+      {
+        name: 'oncall-brain-0',
+        ready: '1/1',
+        status: 'Running',
+        restarts: 'too many',
+        age: '10y',
+      },
+      {
+        name: 'imposter-syndrome-6d9c',
+        ready: '0/1',
+        status: 'CrashLoopBackOff',
+        restarts: 999,
+        age: 'forever',
+        note: 'HPA not configured. Self-doubt scales automatically.',
+      },
+      {
+        name: 'coffee-maker-0',
+        ready: '1/1',
+        status: 'Running',
+        restarts: 1,
+        age: 'today',
+      },
+    ],
+    events: [
+      {
+        type: 'Normal',
+        reason: 'Pulled',
+        object: 'image://ayush-tiwari:latest',
+        message: 'Successfully pulled career highlights.',
+      },
+      {
+        type: 'Warning',
+        reason: 'FailedScheduling',
+        object: 'meeting/standup-15m',
+        message: 'Insufficient focus. Rescheduled to async.',
+      },
+      {
+        type: 'Normal',
+        reason: 'Scaled',
+        object: 'deployment/platform-skills',
+        message: 'HPA added Kubernetes, Terraform, and ArgoCD.',
+      },
+    ],
+    live_metrics_note: 'Counters below are fictional. Your monitoring stack is safe.',
+    hints: {
+      json: '/status.json',
+      liveness: '/health',
+      home: '/',
+    },
+  };
+}
+
+export function getHealthJson() {
+  return JSON.stringify(getHealthPayload(), null, 2);
+}
+
+export function getStatusJson() {
+  return JSON.stringify(getStatusPayload(), null, 2);
+}
+
+/** Pun metrics that tick up on /status for smiles (not real telemetry). */
+export const liveMetricSeeds = [
+  { key: 'yaml_lines_reviewed', label: 'YAML lines reviewed (lifetime)', start: 847_291, step: [3, 17, 42] },
+  { key: 'terraform_plans_on_friday', label: 'Terraform plans sent to prod on Friday', start: 0, step: [0, 0, 0] },
+  { key: 'times_blamed_dns', label: 'Incidents blamed on DNS', start: 12, step: [0, 1, 0] },
+  { key: 'kubectl_explain_runs', label: 'kubectl explain runs', start: 2_048, step: [1, 4, 9] },
+  { key: 'coffee_cups_today', label: 'Coffee cups (today)', start: 2, step: [0, 1, 1] },
+  { key: 'postmortems_with_snacks', label: 'Blameless postmortems with snacks', start: 37, step: [0, 0, 1] },
+  { key: 'pipelines_green', label: 'Pipelines currently green', start: 11, step: [-1, 2, 0] },
+  { key: 'unread_platform_slacks', label: 'Unread #platform messages', start: 3, step: [1, 5, 2] },
+] as const;

--- a/src/islands/OpsLiveMetrics.tsx
+++ b/src/islands/OpsLiveMetrics.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import { liveMetricSeeds } from '../data/ops-endpoints';
+
+type MetricState = {
+  key: string;
+  label: string;
+  value: number;
+  step: readonly number[];
+};
+
+function initMetrics(): MetricState[] {
+  return liveMetricSeeds.map((seed) => ({
+    key: seed.key,
+    label: seed.label,
+    value: seed.start,
+    step: seed.step,
+  }));
+}
+
+function formatValue(value: number) {
+  return value.toLocaleString('en-US');
+}
+
+export default function OpsLiveMetrics() {
+  const [metrics, setMetrics] = useState<MetricState[]>(initMetrics);
+  useEffect(() => {
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reducedMotion) return;
+
+    let tick = 0;
+    const interval = window.setInterval(() => {
+      setMetrics((current) =>
+        current.map((metric) => {
+          const delta = metric.step[tick % metric.step.length] ?? 0;
+          const next = metric.value + delta;
+          return {
+            ...metric,
+            value: metric.key === 'terraform_plans_on_friday' ? 0 : Math.max(0, next),
+          };
+        })
+      );
+      tick += 1;
+    }, 2200);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="ops-live" aria-live="polite">
+      <p className="ops-section-title">Live telemetry (definitely real)</p>
+      <ul className="ops-live__list">
+        {metrics.map((metric) => (
+          <li key={metric.key}>
+            <span className="ops-live__label">{metric.label}</span>
+            <span className="ops-live__value">{formatValue(metric.value)}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="ops-note">Counters are satire. Your Prometheus is not haunted.</p>
+      <style>{`
+        .ops-live__list {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          font-family: var(--font-mono);
+          font-size: 0.72rem;
+        }
+        .ops-live__list li {
+          display: flex;
+          justify-content: space-between;
+          gap: 1rem;
+          padding: 0.4rem 0;
+          border-bottom: 1px solid var(--color-border);
+        }
+        .ops-live__label {
+          color: var(--color-text-muted);
+        }
+        .ops-live__value {
+          color: #4ade80;
+          font-variant-numeric: tabular-nums;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/layouts/OpsLayout.astro
+++ b/src/layouts/OpsLayout.astro
@@ -1,0 +1,342 @@
+---
+import cv from '../content/cv.json';
+import { getSiteVersion } from '../data/ops-endpoints';
+
+interface Props {
+  title: string;
+  endpoint: string;
+  description?: string;
+}
+
+const { title, endpoint, description = 'Platform observability endpoints for a static CV.' } = Astro.props;
+const siteVersion = getSiteVersion();
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={description} />
+    <meta name="robots" content="noindex" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <title>{title}</title>
+  </head>
+  <body class="ops-body">
+    <slot name="header" />
+    <main class="ops-main container">
+      <slot />
+    </main>
+    <footer class="ops-footer">
+      <p>
+        <span class="ops-dim">endpoint</span> {endpoint}
+        <span class="ops-sep">·</span>
+        <span class="ops-dim">release</span> v{siteVersion}
+      </p>
+      <p class="ops-footer-links">
+        <a href="/health">/health</a>
+        <a href="/status">/status</a>
+        <a href="/">← home</a>
+      </p>
+    </footer>
+    <p class="site-version" aria-hidden="true">v{siteVersion}</p>
+  </body>
+</html>
+
+<style is:global>
+  @import '../styles/global.css';
+
+  .ops-body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background:
+      radial-gradient(ellipse at 80% 0%, rgba(34, 197, 94, 0.08), transparent 50%),
+      var(--color-bg);
+  }
+
+  .ops-main {
+    flex: 1;
+    padding-block: var(--space-lg) var(--space-xl);
+  }
+
+  .ops-footer {
+    padding: var(--space-md) var(--space-sm) var(--space-lg);
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--color-mono);
+    border-top: 1px solid var(--color-border);
+  }
+
+  .ops-footer p {
+    margin: 0.35rem 0;
+  }
+
+  .ops-footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem 1.25rem;
+  }
+
+  .ops-footer-links a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .ops-footer-links a:hover {
+    color: var(--color-text);
+  }
+
+  .ops-dim {
+    color: var(--color-text-muted);
+  }
+
+  .ops-sep {
+    margin-inline: 0.5rem;
+    opacity: 0.4;
+  }
+
+  .site-version {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 60;
+    margin: 0;
+    padding: 0.35rem 0.6rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border);
+    background: rgba(10, 10, 11, 0.82);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--color-mono);
+    pointer-events: none;
+  }
+</style>
+
+<style is:global>
+  .ops-panel {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: rgba(17, 17, 19, 0.9);
+    overflow: hidden;
+  }
+
+  .ops-panel__bar {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.55rem 0.85rem;
+    border-bottom: 1px solid var(--color-border);
+    background: rgba(255, 255, 255, 0.03);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--color-mono);
+  }
+
+  .ops-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 50%;
+  }
+
+  .ops-dot--red {
+    background: #ef4444;
+  }
+  .ops-dot--amber {
+    background: #f59e0b;
+  }
+  .ops-dot--green {
+    background: #22c55e;
+  }
+
+  .ops-panel__body {
+    padding: var(--space-md);
+  }
+
+  .ops-hero {
+    margin-bottom: var(--space-md);
+  }
+
+  .ops-hero h1 {
+    font-family: var(--font-mono);
+    font-size: clamp(1.1rem, 3vw, 1.35rem);
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+  }
+
+  .ops-hero h1 .ops-status-up {
+    color: #4ade80;
+  }
+
+  .ops-hero h1 .ops-status-ready {
+    color: #60a5fa;
+  }
+
+  .ops-hero p {
+    color: var(--color-text-muted);
+    font-size: 0.92rem;
+    max-width: 62ch;
+  }
+
+  .ops-curl {
+    margin-bottom: var(--space-md);
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-sm);
+    border: 1px dashed var(--color-border-accent);
+    background: rgba(59, 130, 246, 0.06);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.5;
+    overflow-x: auto;
+  }
+
+  .ops-curl code {
+    color: #e2e8f0;
+  }
+
+  .ops-curl .ops-label {
+    display: block;
+    color: var(--color-mono);
+    margin-bottom: 0.35rem;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .ops-grid {
+    display: grid;
+    gap: var(--space-md);
+  }
+
+  @media (min-width: 900px) {
+    .ops-grid--split {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  .ops-section-title {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-mono);
+    margin-bottom: 0.65rem;
+  }
+
+  .ops-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  .ops-table th,
+  .ops-table td {
+    text-align: left;
+    padding: 0.45rem 0.5rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .ops-table th {
+    color: var(--color-mono);
+    font-weight: 500;
+  }
+
+  .ops-badge {
+    display: inline-block;
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.65rem;
+    font-weight: 500;
+    letter-spacing: 0.03em;
+  }
+
+  .ops-badge--up,
+  .ops-badge--healthy,
+  .ops-badge--ready,
+  .ops-badge--resolved,
+  .ops-badge--running,
+  .ops-badge--normal {
+    background: rgba(34, 197, 94, 0.15);
+    color: #4ade80;
+  }
+
+  .ops-badge--degraded,
+  .ops-badge--warning,
+  .ops-badge--mitigated,
+  .ops-badge--flapping {
+    background: rgba(245, 158, 11, 0.15);
+    color: #fbbf24;
+  }
+
+  .ops-badge--denied,
+  .ops-badge--closed {
+    background: rgba(148, 163, 184, 0.12);
+    color: #94a3b8;
+  }
+
+  .ops-badge--crash {
+    background: rgba(239, 68, 68, 0.15);
+    color: #f87171;
+  }
+
+  .ops-json {
+    margin: 0;
+    padding: var(--space-md);
+    overflow-x: auto;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    line-height: 1.55;
+    color: #cbd5e1;
+    white-space: pre;
+  }
+
+  .ops-json .key {
+    color: #7dd3fc;
+  }
+  .ops-json .str {
+    color: #86efac;
+  }
+  .ops-json .num {
+    color: #fcd34d;
+  }
+  .ops-json .bool {
+    color: #c4b5fd;
+  }
+
+  .ops-note {
+    margin-top: var(--space-sm);
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .ops-compliance {
+    margin-top: var(--space-md);
+    padding: var(--space-sm) var(--space-md);
+    border-left: 3px solid var(--color-accent);
+    background: rgba(59, 130, 246, 0.06);
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+  }
+
+  .ops-compliance strong {
+    color: var(--color-text);
+    font-weight: 500;
+  }
+
+  .ops-compliance a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+</style>

--- a/src/pages/health.astro
+++ b/src/pages/health.astro
@@ -1,0 +1,79 @@
+---
+import OpsLayout from '../layouts/OpsLayout.astro';
+import OpsHeader from '../components/ops/OpsHeader.astro';
+import { getHealthPayload, getHealthJson } from '../data/ops-endpoints';
+
+const payload = getHealthPayload();
+const json = getHealthJson();
+
+function badgeClass(status: string) {
+  const s = status.toLowerCase();
+  if (['up', 'healthy', 'ready', 'running', 'normal', 'resolved'].includes(s)) return 'ops-badge--up';
+  if (['degraded', 'flapping', 'warning', 'mitigated'].includes(s)) return 'ops-badge--degraded';
+  if (['denied', 'closed'].includes(s)) return 'ops-badge--denied';
+  return 'ops-badge--denied';
+}
+---
+
+<OpsLayout title="Health · Liveness Probe" endpoint="/health">
+  <OpsHeader slot="header" endpoint="/health" jsonPath="/health.json" probeType="liveness" />
+
+  <div class="ops-hero">
+    <h1>
+      <span class="ops-status-up">● UP</span> — liveness probe
+    </h1>
+    <p>{payload.message}</p>
+  </div>
+
+  <div class="ops-grid ops-grid--split">
+    <section class="ops-panel">
+      <div class="ops-panel__bar">
+        <span class="ops-dot ops-dot--red" />
+        <span class="ops-dot ops-dot--amber" />
+        <span class="ops-dot ops-dot--green" />
+        <span>kubectl get checks -o wide</span>
+      </div>
+      <div class="ops-panel__body">
+        <p class="ops-section-title">Component checks</p>
+        <table class="ops-table">
+          <thead>
+            <tr>
+              <th>CHECK</th>
+              <th>STATUS</th>
+              <th>DETAIL</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              Object.entries(payload.checks).map(([name, check]) => (
+                <tr>
+                  <td>{name.replace(/_/g, '-')}</td>
+                  <td>
+                    <span class={`ops-badge ${badgeClass(check.status)}`}>{check.status}</span>
+                  </td>
+                  <td>{check.detail ?? '—'}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ops-panel">
+      <div class="ops-panel__bar">
+        <span class="ops-dot ops-dot--red" />
+        <span class="ops-dot ops-dot--amber" />
+        <span class="ops-dot ops-dot--green" />
+        <span>application/json</span>
+      </div>
+      <pre class="ops-json"><code>{json}</code></pre>
+    </section>
+  </div>
+
+  <p class="ops-compliance">
+    <strong>SRE mandate:</strong> {payload.sre_mandate}. This site ships with /health and /status because
+    platform engineers probe everything, including their own portfolios. Readiness details live at{' '}
+    <a href="/status">/status</a>.
+  </p>
+</OpsLayout>

--- a/src/pages/health.json.ts
+++ b/src/pages/health.json.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from 'astro';
+import { getHealthJson } from '../data/ops-endpoints';
+
+export const prerender = true;
+
+export const GET: APIRoute = () =>
+  new Response(getHealthJson(), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-cache',
+      'X-SRE-Mandate': 'satisfied',
+      'X-Liveness-Probe': 'you-found-it',
+    },
+  });

--- a/src/pages/status.astro
+++ b/src/pages/status.astro
@@ -1,0 +1,235 @@
+---
+import OpsLayout from '../layouts/OpsLayout.astro';
+import OpsHeader from '../components/ops/OpsHeader.astro';
+import OpsLiveMetrics from '../islands/OpsLiveMetrics';
+import { getStatusPayload, getStatusJson } from '../data/ops-endpoints';
+
+const payload = getStatusPayload();
+const json = getStatusJson();
+
+function badgeClass(status: string) {
+  const s = status.toLowerCase();
+  if (['healthy', 'ready', 'running', 'resolved', 'up', 'normal'].includes(s)) return 'ops-badge--up';
+  if (['degraded', 'warning', 'mitigated', 'flapping'].includes(s)) return 'ops-badge--degraded';
+  if (['denied', 'closed', 'completed'].includes(s)) return 'ops-badge--denied';
+  if (['crashloopbackoff'].includes(s)) return 'ops-badge--crash';
+  return 'ops-badge--denied';
+}
+---
+
+<OpsLayout title="Status · Readiness Probe" endpoint="/status">
+  <OpsHeader slot="header" endpoint="/status" jsonPath="/status.json" probeType="readiness" />
+
+  <div class="ops-hero">
+    <h1>
+      <span class="ops-status-ready">● READY</span> — readiness probe
+    </h1>
+    <p>{payload.message}</p>
+  </div>
+
+  <div class="ops-grid">
+    <section class="ops-panel">
+      <div class="ops-panel__bar">
+        <span class="ops-dot ops-dot--red" />
+        <span class="ops-dot ops-dot--amber" />
+        <span class="ops-dot ops-dot--green" />
+        <span>dependencies</span>
+      </div>
+      <div class="ops-panel__body">
+        <table class="ops-table">
+          <thead>
+            <tr>
+              <th>NAME</th>
+              <th>STATUS</th>
+              <th>NOTE</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              payload.dependencies.map((dep) => (
+                <tr>
+                  <td>{dep.name}</td>
+                  <td>
+                    <span class={`ops-badge ${badgeClass(dep.status)}`}>{dep.status}</span>
+                  </td>
+                  <td>{dep.note ?? dep.reason ?? '—'}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ops-panel">
+      <div class="ops-panel__bar">
+        <span class="ops-dot ops-dot--red" />
+        <span class="ops-dot ops-dot--amber" />
+        <span class="ops-dot ops-dot--green" />
+        <span>kubectl get pods</span>
+      </div>
+      <div class="ops-panel__body">
+        <table class="ops-table">
+          <thead>
+            <tr>
+              <th>NAME</th>
+              <th>READY</th>
+              <th>STATUS</th>
+              <th>RESTARTS</th>
+              <th>AGE</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              payload.pods.map((pod) => (
+                <tr>
+                  <td>{pod.name}</td>
+                  <td>{pod.ready}</td>
+                  <td>
+                    <span class={`ops-badge ${badgeClass(pod.status)}`}>{pod.status}</span>
+                  </td>
+                  <td>{pod.restarts}</td>
+                  <td>{pod.age}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+        {
+          payload.pods
+            .filter((p) => 'note' in p)
+            .map((p) => (
+              <p class="ops-note">
+                {p.name}: {'note' in p ? p.note : ''}
+              </p>
+            ))
+        }
+      </div>
+    </section>
+
+    <section class="ops-panel">
+      <div class="ops-panel__bar">
+        <span class="ops-dot ops-dot--red" />
+        <span class="ops-dot ops-dot--amber" />
+        <span class="ops-dot ops-dot--green" />
+        <span>SLO dashboard</span>
+      </div>
+      <div class="ops-panel__body">
+        <table class="ops-table">
+          <thead>
+            <tr>
+              <th>SLO</th>
+              <th>TARGET</th>
+              <th>ACTUAL</th>
+              <th>ERROR BUDGET</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              payload.slos.map((slo) => (
+                <tr>
+                  <td>{slo.name}</td>
+                  <td>{slo.target}</td>
+                  <td>{slo.actual}</td>
+                  <td>{slo.error_budget}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ops-panel">
+      <div class="ops-panel__bar">
+        <span class="ops-dot ops-dot--red" />
+        <span class="ops-dot ops-dot--amber" />
+        <span class="ops-dot ops-dot--green" />
+        <span>incident history (abbreviated)</span>
+      </div>
+      <div class="ops-panel__body">
+        <table class="ops-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>TITLE</th>
+              <th>STATUS</th>
+              <th>RESOLUTION</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              payload.incidents.map((inc) => (
+                <tr>
+                  <td>{inc.id}</td>
+                  <td>{inc.title}</td>
+                  <td>
+                    <span class={`ops-badge ${badgeClass(inc.status)}`}>{inc.status}</span>
+                  </td>
+                  <td>{inc.resolution}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ops-panel">
+      <div class="ops-panel__bar">
+        <span class="ops-dot ops-dot--red" />
+        <span class="ops-dot ops-dot--amber" />
+        <span class="ops-dot ops-dot--green" />
+        <span>cluster events</span>
+      </div>
+      <div class="ops-panel__body">
+        <table class="ops-table">
+          <thead>
+            <tr>
+              <th>TYPE</th>
+              <th>REASON</th>
+              <th>OBJECT</th>
+              <th>MESSAGE</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              payload.events.map((ev) => (
+                <tr>
+                  <td>
+                    <span class={`ops-badge ${badgeClass(ev.type)}`}>{ev.type}</span>
+                  </td>
+                  <td>{ev.reason}</td>
+                  <td>{ev.object}</td>
+                  <td>{ev.message}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ops-panel">
+      <div class="ops-panel__body">
+        <OpsLiveMetrics client:load />
+      </div>
+    </section>
+
+    <section class="ops-panel">
+      <div class="ops-panel__bar">
+        <span class="ops-dot ops-dot--red" />
+        <span class="ops-dot ops-dot--amber" />
+        <span class="ops-dot ops-dot--green" />
+        <span>application/json</span>
+      </div>
+      <pre class="ops-json"><code>{json}</code></pre>
+    </section>
+  </div>
+
+  <p class="ops-compliance">
+    <strong>Capacity:</strong> {payload.capacity.years_experience} experience ·{' '}
+    {payload.capacity.nodes_managed} nodes · {payload.capacity.clusters_operated} clusters ·{' '}
+    {payload.capacity.cloud_savings_usd} optimized. Liveness at <a href="/health">/health</a>.
+  </p>
+</OpsLayout>

--- a/src/pages/status.json.ts
+++ b/src/pages/status.json.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from 'astro';
+import { getStatusJson } from '../data/ops-endpoints';
+
+export const prerender = true;
+
+export const GET: APIRoute = () =>
+  new Response(getStatusJson(), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-cache',
+      'X-SRE-Mandate': 'satisfied',
+      'X-Readiness-Probe': 'hire-me',
+    },
+  });


### PR DESCRIPTION
## Summary

- Adds **liveness** (`/health`, `/health.json`) and **readiness** (`/status`, `/status.json`) endpoints with kubectl-themed HTML dashboards and machine-readable JSON for `curl | jq`.
- Includes playful platform/SRE copy (component checks, dependency table, SLOs, incident history, `kubectl get pods` view).
- Adds a live satire metrics ticker on `/status` (counters tick up; Friday Terraform deploys stay at 0).
- Surfaces discovery links in the site footer (`probes /health /status`).

## Test plan

- [x] Open `/health` and confirm liveness UI and JSON panel render
- [x] Open `/status` and confirm readiness UI, pods table, and live metrics ticker
- [x] Run `curl -s https://dbcelm.github.io/health.json | jq` after deploy
- [x] Run `curl -s https://dbcelm.github.io/status.json | jq` after deploy
- [x] Confirm footer probe links on the home page
- [x] Verify CI security checks pass on the PR
- [x] Merge to `master` and confirm auto-tag deploy succeeds
